### PR TITLE
Call wifi.sta.config call with a table instead of two strings

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -63,8 +63,12 @@ end
 
 -- Connect to my wifi
 function connecting(wifi_ssid, wifi_password)
+	local station_cfg = {}
+	station_cfg.ssid = wifi_ssid
+	station_cfg.pwd = wifi_password
+
     wifi.setmode(wifi.STATION)
-    wifi.sta.config(wifi_ssid, wifi_password)
+    wifi.sta.config(station_cfg)
 
     tmr.alarm(0, 500, 1, function()
         if wifi.sta.getip()==nil then


### PR DESCRIPTION
Seems that the api has been updated since this script was last updated. 

See https://nodemcu.readthedocs.io/en/master/en/modules/wifi/#wifistaconfig